### PR TITLE
HotFix | Corrige problema do oauth2 google não permitir operações após realizar o login

### DIFF
--- a/src/main/java/com/prati/projetomercado/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/prati/projetomercado/security/oauth2/CustomOAuth2UserService.java
@@ -56,6 +56,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private AuthUser registerNewUser(OAuth2UserInfo oAuth2UserInfo) {
         AuthUser authUser = AuthUser.builder()
                 .email(oAuth2UserInfo.getEmail())
+                .username(oAuth2UserInfo.getName())
                 .creationDate(Instant.now())
                 .build();
 

--- a/src/main/java/com/prati/projetomercado/security/oauth2/handlers/OAuth2AuthSuccessHandler.java
+++ b/src/main/java/com/prati/projetomercado/security/oauth2/handlers/OAuth2AuthSuccessHandler.java
@@ -1,21 +1,19 @@
 package com.prati.projetomercado.security.oauth2.handlers;
 
 import com.prati.projetomercado.config.UserDetailsImpl;
-import com.prati.projetomercado.entity.AuthUser;
+import com.prati.projetomercado.entity.AccessToken;
 import com.prati.projetomercado.entity.RefreshToken;
+import com.prati.projetomercado.repository.AccessTokenRepository;
 import com.prati.projetomercado.repository.RefreshTokenRepository;
 import com.prati.projetomercado.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.prati.projetomercado.service.impl.JwtTokenServiceImpl;
-import com.prati.projetomercado.service.impl.UserServiceImpl;
 import com.prati.projetomercado.utils.CookieUtils;
-import com.prati.projetomercado.utils.TokenUtils;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.SneakyThrows;
 import org.apache.coyote.BadRequestException;
-import org.hibernate.query.sqm.TemporalUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -37,6 +35,9 @@ public class OAuth2AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     private HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private AccessTokenRepository accessTokenRepository;
 
 
     @Override
@@ -67,7 +68,16 @@ public class OAuth2AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         String targetUri = redirectUri.orElse(getDefaultTargetUrl());
 
         var authUser = ((UserDetailsImpl) authentication.getPrincipal()).getAuthUser();
-        String accessToken= tokenService.generateToken(authUser, Instant.now().plus(1, ChronoUnit.DAYS));
+        var expiredDate = Instant.now().plus(1, ChronoUnit.DAYS);
+        String accessToken = tokenService.generateToken(authUser, expiredDate);
+        var accessTokenEntity = AccessToken.builder()
+                .token(accessToken)
+                .authUser(authUser)
+                .expiredDate(expiredDate)
+                .build();
+
+        accessTokenRepository.save(accessTokenEntity);
+
         RefreshToken refreshToken= tokenService.generateNewRefreshToken(authUser);
         refreshTokenRepository.save(refreshToken);
 


### PR DESCRIPTION
## 📋 Descrição

Corrige problema do oauth2 google não permitir realizar operações de CRUD em outras rotas por não haver cadastrado o accessToken no banco de dados.

Atualmente a validação pelo filter de autenticação é feita através do seguinte caminho:

*Verifica se o accessToken é um token valido verificando a chave SECRET
  -> Verifica se o email do token ta cadastrado no bd como authUser
  -> Verifica se o token de acesso está cadastrado no BD (Atualmente o token oauth2 estava dando erro nesse trecho)
  -> Checa se o tempo de expiração do token confere com o tempo salvo no BD.

## 🔨 Tipo de mudança

Selecione uma ou mais opções:

- [ ] Chore/Configuração (setup do projeto, ajustes técnicos, ambiente)  
- [ ] Refatoração (melhorias internas sem mudar funcionalidades)  
- [ ] Nova funcionalidade (feature)  
- [x] Bugfix (correção de um bug)  
- [ ] Documentação  
- [ ] Outro (especifique abaixo)


## 📝 Observações

Esse PR precisa ser aprovado rapidamente pra poder testar as outras PRs usando oauth2 google

