### PR TITLE
Corrige parte que não permite conexões quando tem 2 accessTokens ativos

### DIFF
--- a/src/main/java/com/prati/projetomercado/filter/UserAutenticationFilter.java
+++ b/src/main/java/com/prati/projetomercado/filter/UserAutenticationFilter.java
@@ -63,7 +63,13 @@ public class UserAutenticationFilter extends OncePerRequestFilter {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "User not found");
             return;
         }
-        var accessTokenFromRepo = accessTokenRepository.findByAuthUser(user);
+        var accessTokenFromRepo = accessTokenRepository.findByAuthUserAndToken(user, token).orElse(null);
+
+        if (accessTokenFromRepo == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "No token found");
+        }
+
 
         if (accessTokenFromRepo.getExpiredDate().isBefore(Instant.now()))
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "accessToken expired");

--- a/src/main/java/com/prati/projetomercado/repository/AccessTokenRepository.java
+++ b/src/main/java/com/prati/projetomercado/repository/AccessTokenRepository.java
@@ -4,9 +4,14 @@ import com.prati.projetomercado.entity.AccessToken;
 import com.prati.projetomercado.entity.AuthUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface AccessTokenRepository extends JpaRepository<AccessToken, UUID> {
     AccessToken findByAuthUser(AuthUser authUser);
+
+    List<AccessToken> findAllByAuthUser(AuthUser authUser);
+
+    Optional<AccessToken> findByAuthUserAndToken(AuthUser authUser, String token);
 }

--- a/src/main/java/com/prati/projetomercado/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/UserServiceImpl.java
@@ -52,7 +52,8 @@ public class UserServiceImpl implements UserService {
                     List.of(new FieldError("confirmPassword", "Passwords don't match"), new FieldError("password", "Passwords don't match")));
         }
 
-        if (createUserRequest.password().length() < 6) throw new BadCredentialsException(List.of(new FieldError("password", "Min length: 6 characters")));
+        if (createUserRequest.password().length() < 6)
+            throw new BadCredentialsException(List.of(new FieldError("password", "Min length: 6 characters")));
 
         var newUser = AuthUser.builder().email(createUserRequest.email()).username(createUserRequest.username()).password(encoder.encode(createUserRequest.password())).build();
         userRepository.save(newUser);
@@ -70,12 +71,6 @@ public class UserServiceImpl implements UserService {
         }
 
         var userDetailsImpl = (UserDetailsImpl) authentication.getPrincipal();
-
-        var accessTokenEntityOld = accessTokenRepository.findByAuthUser(userDetailsImpl.getAuthUser());
-
-        if (accessTokenEntityOld != null) {
-            accessTokenRepository.delete(accessTokenEntityOld);
-        }
 
         var refreshToken = jwtTokenService.generateNewRefreshToken(userDetailsImpl.getAuthUser());
 
@@ -110,17 +105,16 @@ public class UserServiceImpl implements UserService {
         refreshTokenRepository.save(refreshToken);
 
         var authuser = getAuthUser(accessToken).orElseThrow(() -> new AuthException("user not found"));
+        var accessTokenEntityOld = accessTokenRepository.findByAuthUserAndToken(authuser, accessToken);
+        accessTokenEntityOld.ifPresent(accessTokenEntity -> {
+            accessTokenRepository.delete(accessTokenEntity);
+        });
 
         var newRefreshToken = jwtTokenService.generateNewRefreshToken(authuser);
+
         refreshTokenRepository.save(newRefreshToken);
         var newAccessTokenExpDate = jwtTokenService.expirationAccessTokenDate();
         var newAccessToken = jwtTokenService.generateToken(authuser, newAccessTokenExpDate);
-
-        var accessTokenEntityOld = accessTokenRepository.findByAuthUser(authuser);
-
-        if (accessTokenEntityOld != null) {
-            accessTokenRepository.delete(accessTokenEntityOld);
-        }
 
         var newAccessTokenEntity = AccessToken.builder().authUser(authuser).token(newAccessToken).expiredDate(newAccessTokenExpDate).build();
 


### PR DESCRIPTION
## 📋 Descrição

Corrige o problema que a aplicação quebra quando tem mais de 1 token de acesso no banco

## 🔨 Tipo de mudança

Selecione uma ou mais opções:

- [ ] Chore/Configuração (setup do projeto, ajustes técnicos, ambiente)  
- [ ] Refatoração (melhorias internas sem mudar funcionalidades)  
- [ ] Nova funcionalidade (feature)  
- [ ] Bugfix (correção de um bug)  
- [ ] Documentação  
- [ ] Outro (especifique abaixo)
- [ x ] Hot fix


## 📝 Observações
