### PR TITLE
feat(app): Adiciona endpoint /version para retornar a versão do build…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,14 @@
                         </exclude>
                     </excludes>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/main/java/com/prati/projetomercado/config/SecurityConfiguration.java
+++ b/src/main/java/com/prati/projetomercado/config/SecurityConfiguration.java
@@ -45,7 +45,8 @@ public class SecurityConfiguration {
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/auth/confirm-registration",
-            "/auth/confirm-registration/**"
+            "/auth/confirm-registration/**",
+            "/version"
     };
 
     @Autowired

--- a/src/main/java/com/prati/projetomercado/controller/VersionController.java
+++ b/src/main/java/com/prati/projetomercado/controller/VersionController.java
@@ -1,0 +1,36 @@
+package com.prati.projetomercado.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/version")
+@Tag(name = "Versão", description = "Endpoint para verificar a versão da aplicação")
+public class VersionController {
+
+    // O Spring injeta automaticamente as propriedades de build que o Maven gerou
+    @Autowired
+    private BuildProperties buildProperties;
+
+    @Operation(summary = "Retorna a versão atual da aplicação",
+            description = "Verifica a versão definida no pom.xml do projeto.")
+    @ApiResponse(responseCode = "200", description = "Versão retornada com sucesso")
+    @GetMapping
+    public ResponseEntity<Map<String, String>> getVersion() {
+        Map<String, String> versionInfo = new HashMap<>();
+        versionInfo.put("version", buildProperties.getVersion());
+        versionInfo.put("buildTime", buildProperties.getTime().toString());
+
+        return ResponseEntity.ok(versionInfo);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 ﻿spring.application.name=projetomercado
 #CRIE NA RAIZ DO TEU PROJETO um arquivo chamado .env
-#   tudo que estiver entre ${} é o nome da variavel que deverá ter no .env
+#   tudo que estiver entre ${} Ã© o nome da variavel que deverÃ¡ ter no .env
 spring.config.import=optional:file:.env[.properties]
 
 spring.datasource.url=jdbc:h2:mem:testdb
@@ -19,7 +19,7 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 #logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 #logging.level.org.hibernate.type=trace
 
-## NÃO MODIFICAR ISSO
+## NÃO MODIFICAR ISSO
 spring.devtools.livereload.enabled=false
 spring.devtools.restart.trigger-file=.reloadTriggerIfRestartIsFalse
 


### PR DESCRIPTION
## 📋 Descrição

Endpoint público para expor a versão atual da aplicação.

Alterações:

1.  O `pom.xml` foi configurado para gerar as informações de build (`build-info`).
2.  Foi criado um novo `VersionController.java` que lê a versão do projeto (definida no `pom.xml`) através do `BuildProperties` do Spring Boot.
3.  A nova rota `GET /version` foi adicionada à lista de `PUBLIC_ENDPOINTS` no `SecurityConfiguration`.

Closes \#35

## 🔨 Tipo de mudança

Selecione uma ou mais opções:

  - [ ] Chore/Configuração (setup do projeto, ajustes técnicos, ambiente)  
  - [ ] Refatoração (melhorias internas sem mudar funcionalidades)  
  - [x] Nova funcionalidade (feature)  
  - [ ] Bugfix (correção de um bug)  
  - [ ] Documentação  
  - [ ] Outro (especifique abaixo)

## 📝 Observações

### Como Testar

1.  Inicie a aplicação 
2.  Acesse o Swagger UI 
3.  Encontre o novo Controller **"Versão"** e execute o endpoint `GET /version`.
4.  Resultado Esperado: A API deve retornar um `200 OK` com um JSON contendo a versão e o horário do build
    ```json
    {
      "buildTime": "2025-10-22T21:57:20.090Z",
      "version": "0.0.1-SNAPSHOT"
    }
    ```