### PR TITLE
Fix/47/rota refresh token expirado

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-GOOGLE_OAUTH2_ID=542124276337-321lush0fmhlt0bbkp0us22r258b1fnj.apps.googleusercontent.com
-
-spring.mail.username=5dcc7848c8b330
-spring.mail.password=e81dd56a02351b

--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+GOOGLE_OAUTH2_ID=542124276337-321lush0fmhlt0bbkp0us22r258b1fnj.apps.googleusercontent.com
+
+spring.mail.username=5dcc7848c8b330
+spring.mail.password=e81dd56a02351b

--- a/src/main/java/com/prati/projetomercado/config/SecurityConfiguration.java
+++ b/src/main/java/com/prati/projetomercado/config/SecurityConfiguration.java
@@ -42,7 +42,10 @@ import java.util.List;
 public class SecurityConfiguration {
 
     public static final String[] PUBLIC_ENDPOINTS = {
-            "/auth/**",
+            "/auth/register",
+            "/auth/login",
+            "/auth/confirm-registration",
+            "/auth/refresh-token",
             "/oauth2/**",
             "/swagger-ui.html",
             "/swagger-ui/**",

--- a/src/main/java/com/prati/projetomercado/service/impl/JwtTokenServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/JwtTokenServiceImpl.java
@@ -13,6 +13,8 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Set;
 import java.util.HashSet;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.exceptions.JWTDecodeException;
 
 
 @Service
@@ -57,7 +59,7 @@ public class JwtTokenServiceImpl {
     }
 
     public Instant expirationAccessTokenDate() {
-        return ZonedDateTime.now(ZoneId.of("America/Sao_Paulo")).plusHours(1).toInstant();
+        return ZonedDateTime.now(ZoneId.of("America/Sao_Paulo")).plusSeconds(5).toInstant();
     }
 
     public RefreshToken generateNewRefreshToken(AuthUser user){
@@ -75,6 +77,15 @@ public class JwtTokenServiceImpl {
 
     public boolean isTokenInvalid(String token) {
         return blacklist.contains(token);
+    }
+
+    public String getSubjectFromExpiredToken(String token) {
+        try {
+            DecodedJWT jwt = JWT.decode(token);
+            return jwt.getSubject();
+        } catch (JWTDecodeException exception){
+            throw new JWTVerificationException("Token inválido ou malformado.");
+        }
     }
 
 }

--- a/src/main/java/com/prati/projetomercado/service/impl/JwtTokenServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/JwtTokenServiceImpl.java
@@ -59,7 +59,7 @@ public class JwtTokenServiceImpl {
     }
 
     public Instant expirationAccessTokenDate() {
-        return ZonedDateTime.now(ZoneId.of("America/Sao_Paulo")).plusSeconds(5).toInstant();
+        return ZonedDateTime.now(ZoneId.of("America/Sao_Paulo")).plusHours(1).toInstant();
     }
 
     public RefreshToken generateNewRefreshToken(AuthUser user){

--- a/src/main/java/com/prati/projetomercado/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/UserServiceImpl.java
@@ -188,7 +188,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private Optional<AuthUser> getAuthUser(String accessToken) {
-        var email = jwtTokenService.getSubjectFromToken(accessToken);
+        var email = jwtTokenService.getSubjectFromExpiredToken(accessToken);
         return userRepository.findByEmail(email);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,7 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 spring.devtools.livereload.enabled=false
 spring.devtools.restart.trigger-file=.reloadTriggerIfRestartIsFalse
 
-spring.mail.host=sandbox.smtp.mailtrap.io
+spring.mail.host=live.smtp.mailtrap.io
 spring.mail.port=587
 spring.mail.username=${MT_USERNAME}
 spring.mail.password=${MT_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 ﻿spring.application.name=projetomercado
 #CRIE NA RAIZ DO TEU PROJETO um arquivo chamado .env
-#   tudo que estiver entre ${} Ã© o nome da variavel que deverÃ¡ ter no .env
+#   tudo que estiver entre ${} ÃÂ© o nome da variavel que deverÃÂ¡ ter no .env
 spring.config.import=optional:file:.env[.properties]
 
 spring.datasource.url=jdbc:h2:mem:testdb
@@ -19,11 +19,11 @@ logging.level.org.hibernate.orm.jdbc.bind=TRACE
 #logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 #logging.level.org.hibernate.type=trace
 
-## NÃO MODIFICAR ISSO
+## NÃÂO MODIFICAR ISSO
 spring.devtools.livereload.enabled=false
 spring.devtools.restart.trigger-file=.reloadTriggerIfRestartIsFalse
 
-spring.mail.host=live.smtp.mailtrap.io
+spring.mail.host=sandbox.smtp.mailtrap.io
 spring.mail.port=587
 spring.mail.username=${MT_USERNAME}
 spring.mail.password=${MT_PASSWORD}


### PR DESCRIPTION
## 📋 Descrição

Este PR corrige o bug crítico da **Issue #47**, onde a rota `POST /auth/refresh-token` falhava ao receber um `accessToken` expirado.

O problema era que o filtro de segurança e os serviços validavam a data de expiração do `accessToken` *antes* de verificar o `refreshToken`, o que tornava a rota de atualização de token inútil.

**Implementação da Correção:**
1.  **`JwtTokenServiceImpl`:** Foi criado um novo método, `getSubjectFromExpiredToken`, que usa `JWT.decode()` para extrair o e-mail do token **sem** validar sua data de expiração.
2.  **`UserServiceImpl`:** O método `getAuthUser` (usado pelo `useRefreshToken`) foi atualizado para chamar o novo método `getSubjectFromExpiredToken`.
3.  **Bônus (Bug de Segurança):** Durante os testes, foi identificado que a rota `/auth/test-autenticated` estava pública já que todos os (`/auth/**`) estavam assim sem descrição completa. A lista `PUBLIC_ENDPOINTS` no `SecurityConfiguration` foi corrigida para ser mais específica, protegendo corretamente todas as rotas que exigem autenticação.

Closes #47

## 🔨 Tipo de mudança

Selecione uma ou mais opções:

- [ ] Chore/Configuração (setup do projeto, ajustes técnicos, ambiente)  
- [x] Refatoração (melhorias internas sem mudar funcionalidades)  
- [ ] Nova funcionalidade (feature)  
- [x] Bugfix (correção de um bug)  
- [ ] Documentação  
- [ ] Outro (especifique abaixo)


## 📝 Observações

O fluxo de teste foi crucial para validar esta correção. Para provar que a lógica estava funcionando, o tempo de expiração do `accessToken` foi reduzido temporariamente para 5 segundos no `JwtTokenServiceImpl`.

Modifiquei só pra fazer o teste, está do mesmo jeito do develop
<img width="761" height="68" alt="Captura de tela 2025-10-27 203544" src="https://github.com/user-attachments/assets/6b393272-67a6-40fc-af7c-2090ca2d4968" />

### Como a Melhoria Foi Testada

1.  **Ação (Obter Tokens):** Um usuário fez login (`POST /auth/login`) e recebeu o **Token A** e o **Refresh A**.
2.  **Ação (Esperar Expiração):** Aguardei 5 segundos.
3.  **Teste 1 (Provar Expiração):** Uma chamada para `POST /auth/test-autenticated` foi feita usando o **Token A**.
    * **Resultado:** A API (corretamente) falhou com **`401 Unauthorized`**, provando que o Token A estava expirado.
4.  **Teste 2 (Validar Correção):** Uma chamada foi feita para `POST /auth/refresh-token`, enviando o **Token A** (expirado) no "Authorize" e o **Refresh A** no corpo da requisição.
    * **Resultado:** A API retornou **`200 OK`** com um novo par de tokens (`Token B` e `Refresh B`).