### PR TITLE
fix(auth): Permite refresh token com access token expirado e corrige …

### DIFF
--- a/src/main/java/com/prati/projetomercado/filter/UserAutenticationFilter.java
+++ b/src/main/java/com/prati/projetomercado/filter/UserAutenticationFilter.java
@@ -13,7 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
@@ -32,8 +32,9 @@ public class UserAutenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return Arrays.stream(SecurityConfiguration.PUBLIC_ENDPOINTS)
-                .anyMatch(p -> new MvcRequestMatcher(introspector, p).matches(request));
+        return Arrays.stream(SecurityConfiguration.PUBLIC_ENDPOINTS).anyMatch(
+                stringURI -> PathPatternRequestMatcher.withDefaults().matcher(stringURI).matches(request)
+        );
     }
 
     @Override

--- a/src/main/java/com/prati/projetomercado/filter/UserAutenticationFilter.java
+++ b/src/main/java/com/prati/projetomercado/filter/UserAutenticationFilter.java
@@ -1,6 +1,6 @@
 package com.prati.projetomercado.filter;
 
-import com.prati.projetomercado.advice.ExceptionAdvice;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.prati.projetomercado.config.SecurityConfiguration;
 import com.prati.projetomercado.repository.AccessTokenRepository;
 import com.prati.projetomercado.service.impl.JwtTokenServiceImpl;
@@ -13,12 +13,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Arrays;
 
 @Component
@@ -28,52 +28,39 @@ public class UserAutenticationFilter extends OncePerRequestFilter {
     private final JwtTokenServiceImpl jwtTokenService;
     private final UserDetailsServiceImpl userDetailsService;
     private final AccessTokenRepository accessTokenRepository;
-    private ExceptionAdvice advice;
+    private final HandlerMappingIntrospector introspector;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return Arrays.stream(SecurityConfiguration.PUBLIC_ENDPOINTS).anyMatch(
-                stringURI -> PathPatternRequestMatcher.withDefaults().matcher(stringURI).matches(request)
-        );
+        return Arrays.stream(SecurityConfiguration.PUBLIC_ENDPOINTS)
+                .anyMatch(p -> new MvcRequestMatcher(introspector, p).matches(request));
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-
             String token = TokenUtils.recoveryToken(request.getHeader("Authorization"));
 
-            if (token == null) {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token nao encontrado no header");
+            if (token != null) {
+                // 1. Verifica se o token existe no banco
+                accessTokenRepository.findByToken(token)
+                        .orElseThrow(() -> new JWTVerificationException("Token invalidado (logout) ou não encontrado no banco de dados."));
+
+                // 2. Verifica se o token não expirou (para rotas normais)
+                var email = jwtTokenService.getSubjectFromToken(token); // Este método verifica a expiração
+                var userDetails = userDetailsService.loadUserByUsername(email);
+                var authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-
-            var accessToken = accessTokenRepository.findByToken(token)
-                    .orElse(null);
-
-            if (accessToken == null) {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token não encontrado no banco de dados");
-            }
-
-            assert accessToken != null;
-            if (accessToken.getExpiredDate().isBefore(Instant.now())) {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token expirado");
-
-            }
-            var email = jwtTokenService.getSubjectFromToken(token);
-
-            var userDetails = userDetailsService.loadUserByUsername(email);
-            var authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-            SecurityContextHolder.getContext().setAuthentication(authentication);
 
             filterChain.doFilter(request, response);
 
         } catch (Exception e) {
-            logger.error("Falha no filtro de segurança: ", e);
-            advice.handleException(e);
+            // 3. CORREÇÃO: Responde 401 diretamente (evita o NullPointerException)
+            logger.error("Falha no filtro de segurança: " + e.getMessage());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Token inválido, expirado ou revogado.");
+            return;
         }
     }
-
 }

--- a/src/main/java/com/prati/projetomercado/service/impl/JwtTokenServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/JwtTokenServiceImpl.java
@@ -13,14 +13,21 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Set;
 import java.util.HashSet;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.prati.projetomercado.repository.AccessTokenRepository;
+import lombok.RequiredArgsConstructor;
 
 
 @Service
+@RequiredArgsConstructor
 public class JwtTokenServiceImpl {
     //TODO colocar secret key em um arquivo a parte
     public static final String SECRET_KEY = "MUDAR_DEPOIS";
 
     public static final String ISSUER = "prati-projeto-mercado";
+
+    private final AccessTokenRepository accessTokenRepository;
 
     public String generateToken(AuthUser authUser, Instant expirationDate) {
         try {
@@ -71,10 +78,21 @@ public class JwtTokenServiceImpl {
 
     public void invalidateToken(String token) {
         blacklist.add(token);
+        accessTokenRepository.findByToken(token)
+                .ifPresent(accessTokenRepository::delete);
     }
 
     public boolean isTokenInvalid(String token) {
         return blacklist.contains(token);
+    }
+
+    public String getSubjectFromExpiredToken(String token) {
+        try {
+            DecodedJWT jwt = JWT.decode(token);
+            return jwt.getSubject();
+        } catch (JWTDecodeException exception){
+            throw new JWTVerificationException("Token inválido ou malformado.");
+        }
     }
 
 }

--- a/src/main/java/com/prati/projetomercado/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/UserServiceImpl.java
@@ -144,7 +144,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private Optional<AuthUser> getAuthUser(String accessToken) {
-        var email = jwtTokenService.getSubjectFromToken(accessToken);
+        var email = jwtTokenService.getSubjectFromExpiredToken(accessToken);
         return userRepository.findByEmail(email);
 
 
@@ -152,33 +152,43 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public JwtToken useRefreshToken(String accessToken, UUID refreshTokenId) {
-        final var refreshToken = refreshTokenRepository.findByIdAndExpiresAtAfter(refreshTokenId, Instant.now()).orElseThrow(() -> new AuthException("No refreshToken found / refreshToken expired"));
+
+
+        var accessTokenEntity = accessTokenRepository.findByToken(accessToken)
+                .orElseThrow(() -> new AuthException("Token foi invalidado (logout realizado)"));
+
+        final var refreshToken = refreshTokenRepository
+                .findByIdAndExpiresAtAfter(refreshTokenId, Instant.now())
+                .orElseThrow(() -> new AuthException("No refreshToken found / refreshToken expired"));
 
         if (refreshToken.isAlreadyUsed()) {
             throw new AuthException("Token has already been used");
         }
 
+        if (!refreshToken.getAuthUser().equals(accessTokenEntity.getAuthUser())) {
+            throw new AuthException("Incompatibilidade de tokens.");
+        }
+
         refreshToken.setAlreadyUsed(true);
         refreshTokenRepository.save(refreshToken);
+        accessTokenRepository.delete(accessTokenEntity);
 
-        var authuser = getAuthUser(accessToken).orElseThrow(() -> new AuthException("user not found"));
-        var accessTokenEntityOld = accessTokenRepository.findByAuthUserAndToken(authuser, accessToken);
-        accessTokenEntityOld.ifPresent(accessTokenEntity -> {
-            accessTokenRepository.delete(accessTokenEntity);
-        });
+        var authuser = refreshToken.getAuthUser();
 
         var newRefreshToken = jwtTokenService.generateNewRefreshToken(authuser);
-
         refreshTokenRepository.save(newRefreshToken);
-        var newAccessTokenExpDate = jwtTokenService.expirationAccessTokenDate();
-        var newAccessToken = jwtTokenService.generateToken(authuser, newAccessTokenExpDate);
 
-        var newAccessTokenEntity = AccessToken.builder().authUser(authuser).token(newAccessToken).expiredDate(newAccessTokenExpDate).build();
+        var newAccessExp = jwtTokenService.expirationAccessTokenDate();
+        var newAccessToken = jwtTokenService.generateToken(authuser, newAccessExp);
 
-        accessTokenRepository.save(newAccessTokenEntity);
+        var newAccessEntity = AccessToken.builder()
+                .authUser(authuser)
+                .token(newAccessToken)
+                .expiredDate(newAccessExp)
+                .build();
+        accessTokenRepository.save(newAccessEntity);
 
         return new JwtToken(newAccessToken, newRefreshToken.getId());
-
     }
 
     @Override


### PR DESCRIPTION
## 📋 Descrição

Este PR implementa a correção para a Issue #47, que exigia que a rota POST /auth/refresh-token aceitasse um accessToken expirado para gerar um novo par de tokens.

## 🔨 Tipo de mudança

Selecione uma ou mais opções:

- [ ] Chore/Configuração (setup do projeto, ajustes técnicos, ambiente)  
- [x] Refatoração (melhorias internas sem mudar funcionalidades)  
- [ ] Nova funcionalidade (feature)  
- [x] Bugfix (correção de um bug)  
- [ ] Documentação  
- [ ] Outro (especifique abaixo)

pra ser mais rapido o teste diminuir o plusHours(1) para plusSeconds(5)
