### PR TITLE
Feat/ Implementar busca avançada para NFC-e e Rascunho

### DIFF
--- a/src/main/java/com/prati/projetomercado/controller/NfceController.java
+++ b/src/main/java/com/prati/projetomercado/controller/NfceController.java
@@ -20,7 +20,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.domain.Page;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -34,8 +33,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -78,27 +75,10 @@ public class NfceController {
 
     @GetMapping("/search")
     public ResponseEntity<SuccessResponse<List<NfceResponse>>> searchNfces(
-            @RequestParam(required = false) Long supermarketId,
-
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-            LocalDate date,
-
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-            LocalDate updatedDate,
-
-            @RequestParam(required = false) BigDecimal minTotal,
-            @RequestParam(required = false) BigDecimal maxTotal,
-
+            NfceFilterRequest filter,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-
-        NfceFilterRequest filter = new NfceFilterRequest(
-                supermarketId, date, updatedDate, minTotal, maxTotal
-        );
-
         Page<NfceResponse> data = nfceService.search(filter, page, size);
         PageResponse pageInfo = PageResponse.from(data);
 

--- a/src/main/java/com/prati/projetomercado/controller/NfceController.java
+++ b/src/main/java/com/prati/projetomercado/controller/NfceController.java
@@ -1,5 +1,6 @@
 package com.prati.projetomercado.controller;
 
+import com.prati.projetomercado.dto.request.NfceFilterRequest;
 import com.prati.projetomercado.dto.request.NfcePatchRequest;
 import com.prati.projetomercado.dto.request.NfceRequest;
 import com.prati.projetomercado.dto.response.ErrorResponse;
@@ -19,6 +20,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,6 +34,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -70,6 +74,37 @@ public class NfceController {
     public ResponseEntity<SuccessResponse<NfceResponse>> getNfce(@PathVariable("access-key") String accessKey) {
         NfceResponse data = nfceService.findByAccessKey(accessKey);
         return ResponseEntity.ok(new SuccessResponse<>("Nota fiscal encontrada com sucesso.", data));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<List<NfceResponse>>> searchNfces(
+            @RequestParam(required = false) Long supermarketId,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate updatedDate,
+
+            @RequestParam(required = false) BigDecimal minTotal,
+            @RequestParam(required = false) BigDecimal maxTotal,
+
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+
+        NfceFilterRequest filter = new NfceFilterRequest(
+                supermarketId, date, updatedDate, minTotal, maxTotal
+        );
+
+        Page<NfceResponse> data = nfceService.search(filter, page, size);
+        PageResponse pageInfo = PageResponse.from(data);
+
+        return ResponseEntity.ok(
+                new SuccessResponse<>("Notas fiscais filtradas com sucesso.", data.getContent(), pageInfo)
+        );
     }
 
     @Operation(summary = "Lista todos os estados",

--- a/src/main/java/com/prati/projetomercado/controller/NfceController.java
+++ b/src/main/java/com/prati/projetomercado/controller/NfceController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -73,9 +74,14 @@ public class NfceController {
         return ResponseEntity.ok(new SuccessResponse<>("Nota fiscal encontrada com sucesso.", data));
     }
 
+    @Operation(summary = "Lista todas as notas fiscais filtradas",
+            description = "Retorna uma lista de todas as notas fiscais filtradas do usuário autenticado.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de notas fiscais filtradas retornada com sucesso")
+    })
     @GetMapping("/search")
     public ResponseEntity<SuccessResponse<List<NfceResponse>>> searchNfces(
-            NfceFilterRequest filter,
+            @ParameterObject NfceFilterRequest filter,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {

--- a/src/main/java/com/prati/projetomercado/controller/NfceController.java
+++ b/src/main/java/com/prati/projetomercado/controller/NfceController.java
@@ -111,9 +111,6 @@ public class NfceController {
             @ApiResponse(responseCode = "400", description = "Requisição não pôde ser processada devido a URL inválida ou falha na extração de dados da página",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class))}),
-            @ApiResponse(responseCode = "404", description = "Supermercado não encontrado",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "409", description = "Nota fiscal já existe",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class))})

--- a/src/main/java/com/prati/projetomercado/controller/RascunhoController.java
+++ b/src/main/java/com/prati/projetomercado/controller/RascunhoController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -76,9 +77,15 @@ public class RascunhoController {
         return ResponseEntity.ok(new SuccessResponse<>("Rascunho encontrado com sucesso.", response));
     }
 
+
+    @Operation(summary = "Lista todos os rascunhos filtrados do usuário", description = "Retorna uma lista de todos os rascunhos filtrados pertencentes ao usuário autenticado.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de rascunhos filtrados retornada com sucesso"),
+            @ApiResponse(responseCode = "401", description = "Acesso não autorizado")
+    })
     @GetMapping("/search")
     public ResponseEntity<SuccessResponse<List<RascunhoResponse>>> searchRascunhos(
-            RascunhoFilterRequest filter,
+            @ParameterObject RascunhoFilterRequest filter,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {

--- a/src/main/java/com/prati/projetomercado/controller/RascunhoController.java
+++ b/src/main/java/com/prati/projetomercado/controller/RascunhoController.java
@@ -1,6 +1,7 @@
 package com.prati.projetomercado.controller;
 
 import com.prati.projetomercado.dto.request.CreateRascunhoRequest;
+import com.prati.projetomercado.dto.request.RascunhoFilterRequest;
 import com.prati.projetomercado.dto.request.UpdateRascunhoRequest;
 import com.prati.projetomercado.dto.response.PageResponse;
 import com.prati.projetomercado.dto.response.RascunhoResponse;
@@ -15,7 +16,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -65,6 +74,18 @@ public class RascunhoController {
     public ResponseEntity<SuccessResponse<RascunhoResponse>> buscarRascunhoPorId(@PathVariable("id") Long rascunhoId) {
         RascunhoResponse response = rascunhoService.buscarRascunhoPorId(rascunhoId);
         return ResponseEntity.ok(new SuccessResponse<>("Rascunho encontrado com sucesso.", response));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<List<RascunhoResponse>>> searchRascunhos(
+            RascunhoFilterRequest filter,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<RascunhoResponse> response = rascunhoService.searchRascunhos(filter, page, size);
+        PageResponse pageInfo = PageResponse.from(response);
+
+        return ResponseEntity.ok(new SuccessResponse<>("Rascunhos filtrados com sucesso.", response.getContent(), pageInfo));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/prati/projetomercado/dto/request/CreateRascunhoRequest.java
+++ b/src/main/java/com/prati/projetomercado/dto/request/CreateRascunhoRequest.java
@@ -1,7 +1,10 @@
 package com.prati.projetomercado.dto.request;
 
+import java.math.BigDecimal;
+
 public record CreateRascunhoRequest(
         String mercado,
-        String conteudo
+        String conteudo,
+        BigDecimal totalPrice
 ) {
 }

--- a/src/main/java/com/prati/projetomercado/dto/request/NfceFilterRequest.java
+++ b/src/main/java/com/prati/projetomercado/dto/request/NfceFilterRequest.java
@@ -1,0 +1,12 @@
+package com.prati.projetomercado.dto.request;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record NfceFilterRequest(
+        Long supermarketId,
+        LocalDate date,
+        LocalDate updatedDate,
+        BigDecimal minTotal,
+        BigDecimal maxTotal
+) {}

--- a/src/main/java/com/prati/projetomercado/dto/request/NfceFilterRequest.java
+++ b/src/main/java/com/prati/projetomercado/dto/request/NfceFilterRequest.java
@@ -1,12 +1,26 @@
 package com.prati.projetomercado.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record NfceFilterRequest(
+        @Schema(description = "ID do supermercado", example = "1")
         Long supermarketId,
+
+        @Schema(description = "Data da compra", example = "2025-10-01")
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate date,
+
+        @Schema(description = "Data da última atualização", example = "2025-11-01")
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate updatedDate,
+
+        @Schema(description = "Valor mínimo total da compra", example = "50.00")
         BigDecimal minTotal,
+
+        @Schema(description = "Valor máximo total da compra", example = "200.00")
         BigDecimal maxTotal
 ) {}

--- a/src/main/java/com/prati/projetomercado/dto/request/RascunhoFilterRequest.java
+++ b/src/main/java/com/prati/projetomercado/dto/request/RascunhoFilterRequest.java
@@ -1,0 +1,11 @@
+package com.prati.projetomercado.dto.request;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record RascunhoFilterRequest(
+        String mercado,
+        BigDecimal minTotal,
+        BigDecimal maxTotal,
+        LocalDate date
+) {}

--- a/src/main/java/com/prati/projetomercado/dto/request/RascunhoFilterRequest.java
+++ b/src/main/java/com/prati/projetomercado/dto/request/RascunhoFilterRequest.java
@@ -1,11 +1,23 @@
 package com.prati.projetomercado.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.format.annotation.DateTimeFormat;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record RascunhoFilterRequest(
+
+        @Schema(description = "Nome do mercado", example = "Carrefour")
         String mercado,
+
+        @Schema(description = "Valor mínimo total do rascunho", example = "50.00")
         BigDecimal minTotal,
+
+        @Schema(description = "Valor máximo total do rascunho", example = "200.00")
         BigDecimal maxTotal,
+
+        @Schema(description = "Data de criação do rascunho", example = "2025-11-11")
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         LocalDate date
 ) {}

--- a/src/main/java/com/prati/projetomercado/dto/response/NfceResponse.java
+++ b/src/main/java/com/prati/projetomercado/dto/response/NfceResponse.java
@@ -5,6 +5,7 @@ import com.prati.projetomercado.entity.Purchase;
 import com.prati.projetomercado.entity.Supermarket;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -14,6 +15,8 @@ public record NfceResponse(
         LocalDate date,
         BigDecimal totalPrice,
         Boolean isManual,
+        Instant createdAt,
+        Instant updatedAt,
         List<NfceRequest.Item> products
 ) {
     public static NfceResponse from(Purchase purchase) {
@@ -36,6 +39,8 @@ public record NfceResponse(
                 purchase.getDate(),
                 purchase.getTotalPrice(),
                 purchase.isManual(),
+                purchase.getCreatedAt(),
+                purchase.getUpdatedAt(),
                 items
         );
     }

--- a/src/main/java/com/prati/projetomercado/dto/response/RascunhoResponse.java
+++ b/src/main/java/com/prati/projetomercado/dto/response/RascunhoResponse.java
@@ -1,12 +1,14 @@
 package com.prati.projetomercado.dto.response;
 
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
+import java.time.Instant;
 
 public record RascunhoResponse(
         Long id,
         String mercado,
         String conteudo,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        BigDecimal totalPrice,
+        Instant createdAt,
+        Instant updatedAt
 ) {
 }

--- a/src/main/java/com/prati/projetomercado/dto/response/SupermarketResponse.java
+++ b/src/main/java/com/prati/projetomercado/dto/response/SupermarketResponse.java
@@ -2,13 +2,17 @@ package com.prati.projetomercado.dto.response;
 
 import com.prati.projetomercado.entity.Supermarket;
 
+import java.time.Instant;
+
 public record SupermarketResponse(
         Long id,
         String store,
         String cnpj,
         String city,
         String state,
-        Boolean isManual
+        Boolean isManual,
+        Instant createdAt,
+        Instant updatedAt
 ) {
     public static SupermarketResponse from(Supermarket market) {
         return new SupermarketResponse(
@@ -17,7 +21,9 @@ public record SupermarketResponse(
                 market.getCnpj(),
                 market.getCity(),
                 market.getState(),
-                market.isManual()
+                market.isManual(),
+                market.getCreatedAt(),
+                market.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/prati/projetomercado/entity/Purchase.java
+++ b/src/main/java/com/prati/projetomercado/entity/Purchase.java
@@ -60,10 +60,10 @@ public class Purchase {
     private List<Item> items = new ArrayList<>();
 
     @CreationTimestamp
-    private Instant creationDate;
+    private Instant createdAt;
 
     @UpdateTimestamp
-    private Instant updatedDate;
+    private Instant updatedAt;
 
     @Column(name = "manual", nullable = false)
     private boolean manual;

--- a/src/main/java/com/prati/projetomercado/entity/Purchase.java
+++ b/src/main/java/com/prati/projetomercado/entity/Purchase.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -60,6 +61,9 @@ public class Purchase {
 
     @CreationTimestamp
     private Instant creationDate;
+
+    @UpdateTimestamp
+    private Instant updatedDate;
 
     @Column(name = "manual", nullable = false)
     private boolean manual;

--- a/src/main/java/com/prati/projetomercado/entity/Rascunho.java
+++ b/src/main/java/com/prati/projetomercado/entity/Rascunho.java
@@ -1,11 +1,25 @@
 package com.prati.projetomercado.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
+import java.time.Instant;
 
 //atualizações de lombok
 @Getter
@@ -33,14 +47,17 @@ public class Rascunho {
 
     @CreationTimestamp // Marca o campo para ser preenchido automaticamente com a data e hora de criação
     @Column(name = "created_at", updatable = false) // Nome da coluna e impede que seja atualizada
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @UpdateTimestamp // Marca o campo para ser preenchido automaticamente com a data e hora da última atualização
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     // --- Relacionamento com o Usuário ---
     @ManyToOne(fetch = FetchType.LAZY) // Define um relacionamento "Muitos-para-Um": Muitos rascunhos podem pertencer a Um usuário.
     @JoinColumn(name = "user_id", nullable = false) // Define a coluna de chave estrangeira (FK) na tabela 'rascunhos'
     private AuthUser user;
+
+    @Column(name = "total_price")
+    private BigDecimal totalPrice;
 }

--- a/src/main/java/com/prati/projetomercado/entity/Supermarket.java
+++ b/src/main/java/com/prati/projetomercado/entity/Supermarket.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.Instant;
 import java.util.List;
@@ -49,7 +50,10 @@ public class Supermarket {
     private List<Catalog> catalogItems;
 
     @CreationTimestamp
-    private Instant creationDate;
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
 
     @Column(name = "manual", nullable = false)
     private boolean manual;

--- a/src/main/java/com/prati/projetomercado/repository/PurchaseRepository.java
+++ b/src/main/java/com/prati/projetomercado/repository/PurchaseRepository.java
@@ -6,10 +6,11 @@ import com.prati.projetomercado.entity.Supermarket;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
 
-public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
+public interface PurchaseRepository extends JpaRepository<Purchase, Long>, JpaSpecificationExecutor<Purchase> {
     Optional<Purchase> findByAccessKey(String accessKey);
 
     Optional<Purchase> findBySupermarket(Supermarket supermarket);

--- a/src/main/java/com/prati/projetomercado/repository/RascunhoRepository.java
+++ b/src/main/java/com/prati/projetomercado/repository/RascunhoRepository.java
@@ -5,13 +5,14 @@ import com.prati.projetomercado.entity.Rascunho;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository // Anotação que marca esta interface como um componente de repositório do Spring
-public interface RascunhoRepository extends JpaRepository<Rascunho, Long> {
+public interface RascunhoRepository extends JpaRepository<Rascunho, Long>, JpaSpecificationExecutor<Rascunho> {
 
     // --- MÉTODOS MÁGICOS DO SPRING DATA JPA ---
 

--- a/src/main/java/com/prati/projetomercado/repository/spec/PurchaseSpecification.java
+++ b/src/main/java/com/prati/projetomercado/repository/spec/PurchaseSpecification.java
@@ -1,0 +1,43 @@
+package com.prati.projetomercado.repository.spec;
+
+import com.prati.projetomercado.entity.Purchase;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+public class PurchaseSpecification {
+
+    public static Specification<Purchase> hasSupermarket(Long supermarketId) {
+        return (root, query, cb) ->
+                supermarketId == null ? null :
+                        cb.equal(root.get("supermarket").get("id"), supermarketId);
+    }
+
+    public static Specification<Purchase> hasDate(LocalDate date) {
+        return (root, query, cb) ->
+                date == null ? null : cb.equal(root.get("date"), date);
+    }
+
+    public static Specification<Purchase> hasUpdatedDate(LocalDate updatedDate) {
+        return (root, query, cb) -> {
+            if (updatedDate == null) return null;
+
+            Instant startOfDay = updatedDate.atStartOfDay(ZoneOffset.UTC).toInstant();
+            Instant endOfDay = updatedDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+            return cb.between(root.get("updatedDate"), startOfDay, endOfDay);
+        };
+    }
+
+    public static Specification<Purchase> hasTotalBetween(BigDecimal min, BigDecimal max) {
+        return (root, query, cb) -> {
+            if (min == null && max == null) return null;
+            if (min == null) return cb.lessThanOrEqualTo(root.get("totalPrice"), max);
+            if (max == null) return cb.greaterThanOrEqualTo(root.get("totalPrice"), min);
+            return cb.between(root.get("totalPrice"), min, max);
+        };
+    }
+}

--- a/src/main/java/com/prati/projetomercado/repository/spec/PurchaseSpecification.java
+++ b/src/main/java/com/prati/projetomercado/repository/spec/PurchaseSpecification.java
@@ -1,5 +1,6 @@
 package com.prati.projetomercado.repository.spec;
 
+import com.prati.projetomercado.entity.AuthUser;
 import com.prati.projetomercado.entity.Purchase;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -9,6 +10,11 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 
 public class PurchaseSpecification {
+
+    public static Specification<Purchase> belongsToUser(AuthUser user) {
+        return (root, query, cb) ->
+                user == null ? null : cb.equal(root.get("user"), user);
+    }
 
     public static Specification<Purchase> hasSupermarket(Long supermarketId) {
         return (root, query, cb) ->

--- a/src/main/java/com/prati/projetomercado/repository/spec/RascunhoSpecification.java
+++ b/src/main/java/com/prati/projetomercado/repository/spec/RascunhoSpecification.java
@@ -1,0 +1,47 @@
+package com.prati.projetomercado.repository.spec;
+
+import com.prati.projetomercado.entity.AuthUser;
+import com.prati.projetomercado.entity.Rascunho;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+public class RascunhoSpecification {
+
+    public static Specification<Rascunho> belongsToUser(AuthUser user) {
+        return (root, query, cb) ->
+                user == null ? null : cb.equal(root.get("user"), user);
+    }
+
+    public static Specification<Rascunho> hasMercado(String mercado) {
+        return (root, query, cb) ->
+                mercado == null || mercado.isEmpty()
+                        ? null
+                        : cb.like(cb.lower(root.get("mercado")), "%" + mercado.toLowerCase() + "%");
+    }
+
+    public static Specification<Rascunho> hasTotalBetween(BigDecimal minTotal, BigDecimal maxTotal) {
+        return (root, query, cb) -> {
+            if (minTotal == null && maxTotal == null) return null;
+            if (minTotal != null && maxTotal != null)
+                return cb.between(root.get("totalPrice"), minTotal, maxTotal);
+            if (minTotal != null)
+                return cb.greaterThanOrEqualTo(root.get("totalPrice"), minTotal);
+            return cb.lessThanOrEqualTo(root.get("totalPrice"), maxTotal);
+        };
+    }
+
+    public static Specification<Rascunho> hasCreatedDate(LocalDate date) {
+        return (root, query, cb) -> {
+            if (date == null) return null;
+
+            Instant startOfDay = date.atStartOfDay(ZoneOffset.UTC).toInstant();
+            Instant endOfDay = date.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+            return cb.between(root.get("createdAt"), startOfDay, endOfDay);
+        };
+    }
+}

--- a/src/main/java/com/prati/projetomercado/service/NfceService.java
+++ b/src/main/java/com/prati/projetomercado/service/NfceService.java
@@ -1,5 +1,6 @@
 package com.prati.projetomercado.service;
 
+import com.prati.projetomercado.dto.request.NfceFilterRequest;
 import com.prati.projetomercado.dto.request.NfcePatchRequest;
 import com.prati.projetomercado.dto.request.NfceRequest;
 import com.prati.projetomercado.dto.response.NfceResponse;
@@ -10,6 +11,8 @@ public interface NfceService {
     NfceResponse findByAccessKey(String accessKey);
 
     Page<NfceResponse> findAllByUser(int page, int size);
+
+    Page<NfceResponse> search(NfceFilterRequest filter, int page, int size);
 
     StatesResponse getAvailableStates();
 

--- a/src/main/java/com/prati/projetomercado/service/RascunhoService.java
+++ b/src/main/java/com/prati/projetomercado/service/RascunhoService.java
@@ -1,11 +1,10 @@
 package com.prati.projetomercado.service;
 
 import com.prati.projetomercado.dto.request.CreateRascunhoRequest;
+import com.prati.projetomercado.dto.request.RascunhoFilterRequest;
 import com.prati.projetomercado.dto.request.UpdateRascunhoRequest;
 import com.prati.projetomercado.dto.response.RascunhoResponse;
 import org.springframework.data.domain.Page;
-
-import java.util.List;
 
 public interface RascunhoService {
 
@@ -28,6 +27,8 @@ public interface RascunhoService {
      * @return O rascunho encontrado, formatado como DTO de resposta.
      */
     RascunhoResponse buscarRascunhoPorId(Long rascunhoId);
+
+    Page<RascunhoResponse> searchRascunhos(RascunhoFilterRequest filter, int page, int size);
 
     /**
      * Atualiza um rascunho existente.

--- a/src/main/java/com/prati/projetomercado/service/impl/NfceServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/NfceServiceImpl.java
@@ -1,5 +1,6 @@
 package com.prati.projetomercado.service.impl;
 
+import com.prati.projetomercado.dto.request.NfceFilterRequest;
 import com.prati.projetomercado.dto.request.NfcePatchRequest;
 import com.prati.projetomercado.dto.request.NfceRequest;
 import com.prati.projetomercado.dto.response.NfceResponse;
@@ -19,16 +20,17 @@ import com.prati.projetomercado.repository.AuthUserRepository;
 import com.prati.projetomercado.repository.CatalogRepository;
 import com.prati.projetomercado.repository.PurchaseRepository;
 import com.prati.projetomercado.repository.SupermarketRepository;
+import com.prati.projetomercado.repository.spec.PurchaseSpecification;
 import com.prati.projetomercado.service.NfceService;
 import com.prati.projetomercado.utils.EntityBuilderUtils;
-import com.prati.projetomercado.utils.TokenUtils;
-import com.prati.projetomercado.utils.scraper.StatesRegistry;
 import com.prati.projetomercado.utils.scraper.Scraper;
+import com.prati.projetomercado.utils.scraper.StatesRegistry;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,6 +71,26 @@ public class NfceServiceImpl implements NfceService {
 
         Pageable pageable = PageRequest.of(page, size);
         Page<Purchase> purchasesPage = purchaseRepo.findAllByUser(user, pageable);
+
+        return purchasesPage.map(NfceResponse::from);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<NfceResponse> search(NfceFilterRequest filter, int page, int size) {
+        AuthUser user = getAuthenticatedUser();
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Specification<Purchase> spec = Specification.allOf(
+                PurchaseSpecification.hasSupermarket(filter.supermarketId()),
+                PurchaseSpecification.hasDate(filter.date()),
+                PurchaseSpecification.hasUpdatedDate(filter.updatedDate()),
+                PurchaseSpecification.hasTotalBetween(filter.minTotal(), filter.maxTotal()),
+                (root, query, cb) -> cb.equal(root.get("user"), user)
+        );
+
+        Page<Purchase> purchasesPage = purchaseRepo.findAll(spec, pageable);
 
         return purchasesPage.map(NfceResponse::from);
     }

--- a/src/main/java/com/prati/projetomercado/service/impl/NfceServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/NfceServiceImpl.java
@@ -79,15 +79,14 @@ public class NfceServiceImpl implements NfceService {
     @Transactional(readOnly = true)
     public Page<NfceResponse> search(NfceFilterRequest filter, int page, int size) {
         AuthUser user = getAuthenticatedUser();
-
         Pageable pageable = PageRequest.of(page, size);
 
         Specification<Purchase> spec = Specification.allOf(
+                PurchaseSpecification.belongsToUser(user),
                 PurchaseSpecification.hasSupermarket(filter.supermarketId()),
                 PurchaseSpecification.hasDate(filter.date()),
                 PurchaseSpecification.hasUpdatedDate(filter.updatedDate()),
-                PurchaseSpecification.hasTotalBetween(filter.minTotal(), filter.maxTotal()),
-                (root, query, cb) -> cb.equal(root.get("user"), user)
+                PurchaseSpecification.hasTotalBetween(filter.minTotal(), filter.maxTotal())
         );
 
         Page<Purchase> purchasesPage = purchaseRepo.findAll(spec, pageable);

--- a/src/main/java/com/prati/projetomercado/service/impl/RascunhoServiceImpl.java
+++ b/src/main/java/com/prati/projetomercado/service/impl/RascunhoServiceImpl.java
@@ -1,22 +1,23 @@
 package com.prati.projetomercado.service.impl;
 
 import com.prati.projetomercado.dto.request.CreateRascunhoRequest;
+import com.prati.projetomercado.dto.request.RascunhoFilterRequest;
 import com.prati.projetomercado.dto.request.UpdateRascunhoRequest;
 import com.prati.projetomercado.dto.response.RascunhoResponse;
 import com.prati.projetomercado.entity.AuthUser;
 import com.prati.projetomercado.entity.Rascunho;
-import com.prati.projetomercado.repository.AuthUserRepository; // Import que faltava
+import com.prati.projetomercado.repository.AuthUserRepository;
 import com.prati.projetomercado.repository.RascunhoRepository;
+import com.prati.projetomercado.repository.spec.RascunhoSpecification;
 import com.prati.projetomercado.service.RascunhoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +31,7 @@ public class RascunhoServiceImpl implements RascunhoService {
                 rascunho.getId(),
                 rascunho.getMercado(),
                 rascunho.getConteudo(),
+                rascunho.getTotalPrice(),
                 rascunho.getCreatedAt(),
                 rascunho.getUpdatedAt()
         );
@@ -47,6 +49,7 @@ public class RascunhoServiceImpl implements RascunhoService {
         Rascunho novoRascunho = Rascunho.builder()
                 .mercado(createRascunhoRequest.mercado())
                 .conteudo(createRascunhoRequest.conteudo())
+                .totalPrice(createRascunhoRequest.totalPrice())
                 .user(usuarioLogado)
                 .build();
         Rascunho rascunhoSalvo = rascunhoRepository.save(novoRascunho);
@@ -54,6 +57,7 @@ public class RascunhoServiceImpl implements RascunhoService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<RascunhoResponse> buscarRascunhosDoUsuario(int page, int size) {
         AuthUser usuarioLogado = getUsuarioAutenticado();
 
@@ -64,11 +68,29 @@ public class RascunhoServiceImpl implements RascunhoService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public RascunhoResponse buscarRascunhoPorId(Long rascunhoId) {
         AuthUser usuarioLogado = getUsuarioAutenticado();
         Rascunho rascunho = rascunhoRepository.findRascunhoByUserAndId(usuarioLogado, rascunhoId)
                 .orElseThrow(() -> new RuntimeException("Rascunho não encontrado"));
         return paraRascunhoResponse(rascunho);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<RascunhoResponse> searchRascunhos(RascunhoFilterRequest filter, int page, int size) {
+        AuthUser user = getUsuarioAutenticado();
+        Pageable pageable = PageRequest.of(page, size);
+
+        Specification<Rascunho> spec = Specification.allOf(
+                RascunhoSpecification.belongsToUser(user),
+                RascunhoSpecification.hasMercado(filter.mercado()),
+                RascunhoSpecification.hasTotalBetween(filter.minTotal(), filter.maxTotal()),
+                RascunhoSpecification.hasCreatedDate(filter.date())
+        );
+
+        Page<Rascunho> rascunhosPage = rascunhoRepository.findAll(spec, pageable);
+        return rascunhosPage.map(this::paraRascunhoResponse);
     }
 
     @Override


### PR DESCRIPTION
## 📋 Descrição

<!-- Explique o que foi feito neste PR -->

Esta PR implementa e documenta as rotas de busca avançada para os recursos Rascunho e NFC-e, além de adicionar os campos `createdAt` e `updatedAt` às tabelas Supermarket e NFC-e.

1. `/api/rascunhos/search`

   - *mercado* -> nome sem diferenciação de maiúsculas/minúsculas
   - *date* -> data da criação do rascunho
   - *minTotal* -> preço total mínimo
   - *maxTotal* -> preço total máximo

2. `/api/nfces/search`

   - *supermarketId* -> ID do supermercado específico
   - *date* -> data da compra
   - *updatedDate* -> data da última atualização
   - *minTotal* -> preço total mínimo
   - *maxTotal* -> preço total máximo

## 🔨 Tipo de mudança

Selecione uma ou mais opções:

- [ ] Chore/Configuração (setup do projeto, ajustes técnicos, ambiente)  
- [ ] Refatoração (melhorias internas sem mudar funcionalidades)  
- [x] Nova funcionalidade (feature)  
- [ ] Bugfix (correção de um bug)  
- [x] Documentação  
- [ ] Outro (especifique abaixo)


## 📝 Observações

<!-- Algum ponto de atenção? Algo que precisa ser revisado com cuidado? -->
   - Ambas as rotas são paginadas
   - Todos os parâmetros são opcionais
   - Os campos `createdAt` e `updatedAt` são retornados nas respostas da API